### PR TITLE
Backport to 1.14

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,15 +3,15 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.15.2
-yarn_mappings=1.15.2+build.17
+minecraft_version=1.14.4
+yarn_mappings=1.14.4+build.18
 loader_version=0.11.1
 
 # Mod Properties
-mod_version=1.1.0+mc1.15-1.16
+mod_version=1.1.0+mc1.14
 maven_group=me.sizableshrimp
 archives_base_name=Mc122477Fix-fabric
 
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
-fabric_version=0.28.5+1.15
+fabric_version=0.28.5+1.14

--- a/src/main/java/me/sizableshrimp/mc122477fix/mixin/MixinKeyboard.java
+++ b/src/main/java/me/sizableshrimp/mc122477fix/mixin/MixinKeyboard.java
@@ -19,7 +19,7 @@ public class MixinKeyboard {
             ci.cancel();
     }
 
-    @Inject(method = "onChar", at = @At(value = "FIELD", target = "Lnet/minecraft/client/Keyboard;client:Lnet/minecraft/client/MinecraftClient;", ordinal = 0), cancellable = true)
+    @Inject(method = "onChar", at = @At(value = "FIELD", target = "Lnet/minecraft/client/MinecraftClient;currentScreen:Lnet/minecraft/client/gui/screen/Screen;", ordinal = 0), cancellable = true)
     private void injectOnChar(long window, int i, int j, CallbackInfo ci) {
         ActionResult result = KeyboardCharTypedCallback.EVENT.invoker().onCharTyped(window, i, j);
 

--- a/src/main/java/me/sizableshrimp/mc122477fix/mixin/MixinMinecraftClient.java
+++ b/src/main/java/me/sizableshrimp/mc122477fix/mixin/MixinMinecraftClient.java
@@ -1,16 +1,16 @@
 package me.sizableshrimp.mc122477fix.mixin;
 
-import com.mojang.blaze3d.systems.RenderSystem;
 import me.sizableshrimp.mc122477fix.GLFWPollCallback;
+import net.minecraft.client.MinecraftClient;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(RenderSystem.class)
-public class MixinRenderSystem {
-    @Inject(method = "flipFrame", at = @At(value = "INVOKE", target = "Lorg/lwjgl/glfw/GLFW;glfwPollEvents()V", shift = At.Shift.AFTER))
-    private static void injectGlfwPoll(CallbackInfo ci) {
+@Mixin(MinecraftClient.class)
+public class MixinMinecraftClient {
+    @Inject(method = "tick", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/platform/GLX;pollEvents()V", shift = At.Shift.AFTER, ordinal = 0))
+    private void injectGlfwPoll(CallbackInfo ci) {
         GLFWPollCallback.EVENT.invoker().onPoll();
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -26,6 +26,6 @@
   "depends": {
     "fabricloader": ">=0.10.0",
     "fabric": "*",
-    "minecraft": ">=1.15"
+    "minecraft": "1.14.x"
   }
 }


### PR DESCRIPTION
This is based off of #4 with small changes to support 1.14, which uses a slightly different system for polling GLFW events compared to 1.15+.

This should be merged into a new branch named `fabric-1.14`.

Here is a compiled JAR file for Curseforge: [Mc122477Fix-fabric-1.1.0+mc1.14.jar](https://cdn.discordapp.com/attachments/474641238390210562/813363111812923452/Mc122477Fix-fabric-1.1.0mc1.14.jar)