### PR TITLE
Update to Minecraft 1.19.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,77 +1,80 @@
 plugins {
-    id 'fabric-loom' version '0.6-SNAPSHOT'
-    id 'maven-publish'
+	id 'fabric-loom' version '1.1-SNAPSHOT'
+	id 'maven-publish'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
-archivesBaseName = project.archives_base_name
 version = project.mod_version
 group = project.maven_group
 
+repositories {
+	// Add repositories to retrieve artifacts from in here.
+	// You should only use this when depending on other mods because
+	// Loom adds the essential maven repositories to download Minecraft and libraries from automatically.
+	// See https://docs.gradle.org/current/userguide/declaring_repositories.html
+	// for more information about repositories.
+}
+
 dependencies {
-    //to change the versions see the gradle.properties file
-    minecraft "com.mojang:minecraft:${project.minecraft_version}"
-    mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
-    modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+	// To change the versions see the gradle.properties file
+	minecraft "com.mojang:minecraft:${project.minecraft_version}"
+	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
+	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
-    // Fabric API. This is technically optional, but you probably want it anyway.
-    modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+	// Fabric API. This is technically optional, but you probably want it anyway.
+	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-    // PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
-    // You may need to force-disable transitiveness on them.
+	// Uncomment the following line to enable the deprecated Fabric API modules.
+	// These are included in the Fabric API production distribution and allow you to update your mod to the latest modules at a later more convenient time.
+
+	// modImplementation "net.fabricmc.fabric-api:fabric-api-deprecated:${project.fabric_version}"
+}
+
+base {
+	archivesName = project.archives_base_name
 }
 
 processResources {
-    inputs.property "version", project.version
+	inputs.property "version", project.version
 
-    from(sourceSets.main.resources.srcDirs) {
-        include "fabric.mod.json"
-        expand "version": project.version
-    }
-
-    from(sourceSets.main.resources.srcDirs) {
-        exclude "fabric.mod.json"
-    }
+	filesMatching("fabric.mod.json") {
+		expand "version": project.version
+	}
 }
 
-// ensure that the encoding is set to UTF-8, no matter what the system default is
-// this fixes some edge cases with special characters not displaying correctly
-// see http://yodaconditions.net/blog/fix-for-java-file-encoding-problems-with-gradle.html
-tasks.withType(JavaCompile) {
-    options.encoding = "UTF-8"
+tasks.withType(JavaCompile).configureEach {
+	// Minecraft 1.18 (1.18-pre2) upwards uses Java 17.
+	it.options.release = 17
 }
 
-// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
-// if it is present.
-// If you remove this task, sources will not be generated.
-task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = "sources"
-    from sourceSets.main.allSource
+java {
+	// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
+	// if it is present.
+	// If you remove this line, sources will not be generated.
+	withSourcesJar()
+
+	sourceCompatibility = JavaVersion.VERSION_17
+	targetCompatibility = JavaVersion.VERSION_17
 }
 
 jar {
-    from "LICENSE"
+	from("LICENSE") {
+		rename { "${it}_${base.archivesName.get()}"}
+	}
 }
 
 // configure the maven publication
 publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            // add all the jars that should be included when publishing to maven
-            artifact(remapJar) {
-                builtBy remapJar
-            }
-            artifact(sourcesJar) {
-                builtBy remapSourcesJar
-            }
-        }
-    }
+	publications {
+		mavenJava(MavenPublication) {
+			from components.java
+		}
+	}
 
-    // select the repositories you want to publish to
-    repositories {
-        // uncomment to publish to the local maven
-        // mavenLocal()
-    }
+	// See https://docs.gradle.org/current/userguide/publishing_maven.html for information on how to set up publishing.
+	repositories {
+		// Add repositories to publish to here.
+		// Notice: This block does NOT have the same function as the block in the top level.
+		// The repositories here will be used for publishing your artifact, not for
+		// retrieving dependencies.
+	}
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,15 +3,15 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.15.2
-yarn_mappings=1.15.2+build.17
-loader_version=0.11.1
+minecraft_version=1.19.4
+yarn_mappings=1.19.4+build.1
+loader_version=0.14.19
 
 # Mod Properties
-mod_version=1.1.0+mc1.15-1.16
+mod_version=1.1.0+mc1.19.4
 maven_group=me.sizableshrimp
 archives_base_name=Mc122477Fix-fabric
 
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
-fabric_version=0.28.5+1.15
+fabric_version=0.76.0+1.19.4

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-bin.zip

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,10 +1,10 @@
 pluginManagement {
     repositories {
-        jcenter()
         maven {
             name = 'Fabric'
             url = 'https://maven.fabricmc.net/'
         }
+        mavenCentral()
         gradlePluginPortal()
     }
 }

--- a/src/main/java/me/sizableshrimp/mc122477fix/Mc122477Fix.java
+++ b/src/main/java/me/sizableshrimp/mc122477fix/Mc122477Fix.java
@@ -24,7 +24,7 @@ public class Mc122477Fix implements ClientModInitializer {
                 return ActionResult.PASS;
 
             // If the chat or command key was pressed, store what poll count it happened on.
-            if (client.options.keyChat.matchesKey(key, scancode) || client.options.keyCommand.matchesKey(key, scancode)) {
+            if (client.options.chatKey.matchesKey(key, scancode) || client.options.commandKey.matchesKey(key, scancode)) {
                 this.prevKeyPoll = this.pollCount;
             } else {
                 // Otherwise, set to -1

--- a/src/main/java/me/sizableshrimp/mc122477fix/mixin/MixinRenderSystem.java
+++ b/src/main/java/me/sizableshrimp/mc122477fix/mixin/MixinRenderSystem.java
@@ -9,7 +9,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(RenderSystem.class)
 public class MixinRenderSystem {
-    @Inject(method = "flipFrame", at = @At(value = "INVOKE", target = "Lorg/lwjgl/glfw/GLFW;glfwPollEvents()V", shift = At.Shift.AFTER))
+    @Inject(method = "pollEvents",
+            at = @At(value = "INVOKE", target = "Lorg/lwjgl/glfw/GLFW;glfwPollEvents()V", shift = At.Shift.AFTER),
+            remap = false)
     private static void injectGlfwPoll(CallbackInfo ci) {
         GLFWPollCallback.EVENT.invoker().onPoll();
     }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,8 +24,8 @@
     "mc122477fix.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.10.0",
+    "fabricloader": ">=0.14.18",
     "fabric": "*",
-    "minecraft": ">=1.15"
+    "minecraft": ">=1.19.4"
   }
 }


### PR DESCRIPTION
Updates Gradle and Loom as well as needed.

I'm not sure if this should be in a separate branch or not, I think merging into `fabric-1.16` is best, unless older versions will get an update in future (seems unlikely tbh). However, the choice is up to you to merge it into `fabric-1.16` or make a new `fabric-1.19.4` branch. The latter could be more consistent, I guess.

Download JAR (ZIP since GitHub doesn't let me upload JARs): [Mc122477Fix-fabric-1.1.0+mc1.19.4.zip](https://github.com/RecursiveG/Mc122477Fix/files/11182255/Mc122477Fix-fabric-1.1.0%2Bmc1.19.4.zip)

This will also need corresponding tag `fabric-1.1.0mc1.19.4` (consistent with previous tag formats) and publishing to CurseForge/Modrinth.
